### PR TITLE
Implement unified API response and server-driven pagination

### DIFF
--- a/ec/ec-backend/src/main/java/com/example/ecbackend/common/PageResult.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/common/PageResult.java
@@ -1,0 +1,29 @@
+package com.example.ecbackend.common;
+
+import java.util.List;
+
+public class PageResult<T> {
+    private List<T> records;
+    private int total;
+
+    public PageResult(List<T> records, int total) {
+        this.records = records;
+        this.total = total;
+    }
+
+    public List<T> getRecords() {
+        return records;
+    }
+
+    public void setRecords(List<T> records) {
+        this.records = records;
+    }
+
+    public int getTotal() {
+        return total;
+    }
+
+    public void setTotal(int total) {
+        this.total = total;
+    }
+}

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/common/Response.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/common/Response.java
@@ -1,0 +1,47 @@
+package com.example.ecbackend.common;
+
+public class Response<T> {
+    private int code;
+    private String msg;
+    private T data;
+
+    public Response() {}
+
+    public Response(int code, String msg, T data) {
+        this.code = code;
+        this.msg = msg;
+        this.data = data;
+    }
+
+    public static <T> Response<T> success(T data) {
+        return new Response<>(200, "success", data);
+    }
+
+    public static <T> Response<T> fail(int code, String msg) {
+        return new Response<>(code, msg, null);
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/controller/ProductCategoryController.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/controller/ProductCategoryController.java
@@ -1,8 +1,8 @@
 package com.example.ecbackend.controller;
 
+import com.example.ecbackend.common.Response;
 import com.example.ecbackend.entity.ProductCategory;
-import com.example.ecbackend.mapper.ProductCategoryMapper;
-import com.example.ecbackend.mapper.ProductMapper;
+import com.example.ecbackend.service.ProductCategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -16,82 +16,61 @@ import java.util.Map;
 public class ProductCategoryController {
 
     @Autowired
-    private ProductCategoryMapper categoryMapper;
-
-    @Autowired
-    private ProductMapper productMapper;
+    private ProductCategoryService categoryService;
 
     @GetMapping
-    public List<ProductCategory> getAll() {
-        return categoryMapper.findAll();
+    public Response<List<ProductCategory>> getAll() {
+        return Response.success(categoryService.getAll());
     }
     @GetMapping("/can-delete/{id}")
-    public Map<String, Object> canDelete(@PathVariable Integer id) {
-        Map<String, Object> result = new HashMap<>();
-        int count = productMapper.countByCategoryId(id); // 查询该分类下商品数量
+    public Response<String> canDelete(@PathVariable Integer id) {
+        int count = categoryService.countProductsByCategory(id); // 查询该分类下商品数量
         if (count > 0) {
-            result.put("code", 1);
-            result.put("message", "该分类下仍有商品，无法删除");
-        } else {
-            result.put("code", 0);
+            return Response.fail(1, "该分类下仍有商品，无法删除");
         }
-        return result;
+        return Response.success(null);
     }
     
     @PostMapping
-    public Map<String, Object> addCategory(@RequestBody ProductCategory category) {
-        Map<String, Object> result = new HashMap<>();
+    public Response<String> addCategory(@RequestBody ProductCategory category) {
         try {
             System.out.println("🟢 添加分类请求:");
             System.out.println("分类名: " + category.getName());
             System.out.println("父类ID: " + category.getParentId());
 
-            categoryMapper.insert(category);
-
-            result.put("code", 0);
-            result.put("message", "添加成功");
+            categoryService.addCategory(category);
+            return Response.success(null);
         } catch (Exception e) {
             e.printStackTrace();
-            result.put("code", 1);
-            result.put("message", "添加失败");
+            return Response.fail(1, "添加失败");
         }
-        return result;
     }
     @GetMapping("/parent/{parentId}")
-    public List<ProductCategory> getByParentId(@PathVariable Integer parentId) {
-        return categoryMapper.findByParentId(parentId);
+    public Response<List<ProductCategory>> getByParentId(@PathVariable Integer parentId) {
+        return Response.success(categoryService.getByParentId(parentId));
     }
     @PutMapping("/{id}")
-    public Map<String, Object> updateCategoryName(@PathVariable Integer id, @RequestBody Map<String, String> body) {
-        Map<String, Object> result = new HashMap<>();
+    public Response<String> updateCategoryName(@PathVariable Integer id, @RequestBody Map<String, String> body) {
         try {
             String name = body.get("name");
-            categoryMapper.updateNameById(id, name);
-            result.put("code", 0);
-            result.put("message", "修改成功");
+            categoryService.updateName(id, name);
+            return Response.success(null);
         } catch (Exception e) {
             e.printStackTrace();
-            result.put("code", 1);
-            result.put("message", "修改失败");
+            return Response.fail(1, "修改失败");
         }
-        return result;
     }
 
     @DeleteMapping("/{id}")
-    public Map<String, Object> deleteCategory(@PathVariable Integer id) {
-        Map<String, Object> result = new HashMap<>();
+    public Response<String> deleteCategory(@PathVariable Integer id) {
         try {
-            categoryMapper.deleteById(id);
-            result.put("code", 0);
-            result.put("message", "删除成功");
+            categoryService.deleteById(id);
+            return Response.success(null);
         } catch (DataIntegrityViolationException e) {
-            result.put("code", 1);
-            result.put("message", "删除失败：该分类下仍有商品，请先删除商品");
+            return Response.fail(1, "删除失败：该分类下仍有商品，请先删除商品");
         } catch (Exception e) {
             e.printStackTrace();
-            result.put("code", 2);
-            result.put("message", "删除失败：服务器错误");
+            return Response.fail(2, "删除失败：服务器错误");
         }
-        return result;
     }
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/controller/ProductController.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/controller/ProductController.java
@@ -1,7 +1,9 @@
 package com.example.ecbackend.controller;
 
+import com.example.ecbackend.common.PageResult;
+import com.example.ecbackend.common.Response;
 import com.example.ecbackend.entity.Product;
-import com.example.ecbackend.mapper.ProductMapper;
+import com.example.ecbackend.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,31 +15,35 @@ import java.util.List;
 public class ProductController {
 
     @Autowired
-    private ProductMapper productMapper;
+    private ProductService productService;
 
     @GetMapping
-    public List<Product> getAllProducts() {
-        return productMapper.findAll();
+    public Response<PageResult<Product>> getAllProducts(@RequestParam(defaultValue = "1") int page,
+                                                        @RequestParam(defaultValue = "10") int size) {
+        return Response.success(productService.getProductsByPage(page, size));
     }
 
     @GetMapping("/{id}")
-    public Product getProductById(@PathVariable Integer id) {
-        return productMapper.findById(id);
+    public Response<Product> getProductById(@PathVariable Integer id) {
+        return Response.success(productService.getById(id));
     }
 
     @PostMapping
-    public void addProduct(@RequestBody Product product) {
-        productMapper.insert(product);
+    public Response<Void> addProduct(@RequestBody Product product) {
+        productService.addProduct(product);
+        return Response.success(null);
     }
 
     @PutMapping("/{id}")
-    public void updateProduct(@PathVariable Integer id, @RequestBody Product product) {
+    public Response<Void> updateProduct(@PathVariable Integer id, @RequestBody Product product) {
         product.setId(id);
-        productMapper.update(product);
+        productService.updateProduct(product);
+        return Response.success(null);
     }
 
     @DeleteMapping("/{id}")
-    public void deleteProduct(@PathVariable Integer id) {
-        productMapper.deleteById(id);
+    public Response<Void> deleteProduct(@PathVariable Integer id) {
+        productService.deleteProduct(id);
+        return Response.success(null);
     }
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/controller/UserController.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.ecbackend.controller;
 
+import com.example.ecbackend.common.Response;
 import com.example.ecbackend.entity.User;
 import com.example.ecbackend.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,32 +22,25 @@ public class UserController {
 
     // ✅ 注册接口
     @PostMapping("/register")
-    public Map<String, Object> register(@RequestBody User user) {
-        Map<String, Object> result = new HashMap<>();
+    public Response<String> register(@RequestBody User user) {
         User exist = userService.findByUsername(user.getUsername());
 
         if (exist != null) {
-            result.put("code", 1);
-            result.put("message", "用户名已存在");
-            return result;
+            return Response.fail(1, "用户名已存在");
         }
 
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         try {
             userService.register(user);
-            result.put("code", 0);
-            result.put("message", "注册成功");
+            return Response.success("注册成功");
         } catch (Exception e) {
-            result.put("code", 2);
-            result.put("message", "注册失败，服务器错误");
-            e.printStackTrace(); // ✅ 控制台打印真实错误
+            e.printStackTrace();
+            return Response.fail(2, "注册失败，服务器错误");
         }
-
-        return result;
     }
 
     @PostMapping("/login")
-    public Map<String, Object> login(@RequestBody User user) {
+    public Response<Map<String, Object>> login(@RequestBody User user) {
         Map<String, Object> result = new HashMap<>();
         User dbUser = userService.findByUsername(user.getUsername());
 
@@ -61,17 +55,11 @@ public class UserController {
         }
 
         if (dbUser != null && passwordEncoder.matches(user.getPassword(), dbUser.getPassword())) {
-            result.put("code", 0);
-            result.put("message", "登录成功");
-            result.put("data", Map.of(
-                "username", dbUser.getUsername(),
-                "token", "mock-token"
-            ));
+            result.put("username", dbUser.getUsername());
+            result.put("token", "mock-token");
+            return Response.success(result);
         } else {
-            result.put("code", 1);
-            result.put("message", "用户名或密码错误");
+            return Response.fail(1, "用户名或密码错误");
         }
-
-        return result;
     }
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/entity/Product.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/entity/Product.java
@@ -11,4 +11,6 @@ public class Product {
     private String imageUrl;
     private Integer stock;
     private Integer categoryId;  // 分类ID
+    // 用于接收联表查询的分类名称
+    private String categoryName;
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/mapper/ProductMapper.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/mapper/ProductMapper.java
@@ -3,6 +3,7 @@ package com.example.ecbackend.mapper;
 import com.example.ecbackend.entity.Product;
 import org.apache.ibatis.annotations.Mapper;
 import java.util.List;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface ProductMapper {
@@ -12,5 +13,8 @@ public interface ProductMapper {
     void update(Product product);
     void deleteById(Integer id);
     int countByCategoryId(Integer categoryId);
+    List<Product> selectWithCategory();
+    List<Product> selectByPage(@Param("offset") int offset, @Param("size") int size);
+    int countAll();
 
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/service/ProductCategoryService.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/service/ProductCategoryService.java
@@ -1,5 +1,14 @@
 package com.example.ecbackend.service;
 
-public class ProductCategoryService {
+import com.example.ecbackend.entity.ProductCategory;
 
+import java.util.List;
+
+public interface ProductCategoryService {
+    List<ProductCategory> getAll();
+    List<ProductCategory> getByParentId(Integer parentId);
+    void addCategory(ProductCategory category);
+    void updateName(Integer id, String name);
+    void deleteById(Integer id);
+    int countProductsByCategory(Integer id);
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/service/ProductService.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/service/ProductService.java
@@ -1,5 +1,15 @@
 package com.example.ecbackend.service;
 
-public class ProductService {
+import com.example.ecbackend.common.PageResult;
+import com.example.ecbackend.entity.Product;
 
+import java.util.List;
+
+public interface ProductService {
+    List<Product> getAll();
+    Product getById(Integer id);
+    void addProduct(Product product);
+    void updateProduct(Product product);
+    void deleteProduct(Integer id);
+    PageResult<Product> getProductsByPage(int page, int size);
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/service/impl/ProductCategoryServiceImpl.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/service/impl/ProductCategoryServiceImpl.java
@@ -1,5 +1,50 @@
 package com.example.ecbackend.service.impl;
 
-public class ProductCategoryServiceImpl {
+import com.example.ecbackend.entity.ProductCategory;
+import com.example.ecbackend.mapper.ProductCategoryMapper;
+import com.example.ecbackend.mapper.ProductMapper;
+import com.example.ecbackend.service.ProductCategoryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
+import java.util.List;
+
+@Service
+public class ProductCategoryServiceImpl implements ProductCategoryService {
+
+    @Autowired
+    private ProductCategoryMapper categoryMapper;
+
+    @Autowired
+    private ProductMapper productMapper;
+
+    @Override
+    public List<ProductCategory> getAll() {
+        return categoryMapper.findAll();
+    }
+
+    @Override
+    public List<ProductCategory> getByParentId(Integer parentId) {
+        return categoryMapper.findByParentId(parentId);
+    }
+
+    @Override
+    public void addCategory(ProductCategory category) {
+        categoryMapper.insert(category);
+    }
+
+    @Override
+    public void updateName(Integer id, String name) {
+        categoryMapper.updateNameById(id, name);
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        categoryMapper.deleteById(id);
+    }
+
+    @Override
+    public int countProductsByCategory(Integer id) {
+        return productMapper.countByCategoryId(id);
+    }
 }

--- a/ec/ec-backend/src/main/java/com/example/ecbackend/service/impl/ProductServiceImpl.java
+++ b/ec/ec-backend/src/main/java/com/example/ecbackend/service/impl/ProductServiceImpl.java
@@ -1,5 +1,50 @@
 package com.example.ecbackend.service.impl;
 
-public class ProductServiceImpl {
+import com.example.ecbackend.common.PageResult;
+import com.example.ecbackend.entity.Product;
+import com.example.ecbackend.mapper.ProductMapper;
+import com.example.ecbackend.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
+import java.util.List;
+
+@Service
+public class ProductServiceImpl implements ProductService {
+
+    @Autowired
+    private ProductMapper productMapper;
+
+    @Override
+    public List<Product> getAll() {
+        return productMapper.selectWithCategory();
+    }
+
+    @Override
+    public Product getById(Integer id) {
+        return productMapper.findById(id);
+    }
+
+    @Override
+    public void addProduct(Product product) {
+        productMapper.insert(product);
+    }
+
+    @Override
+    public void updateProduct(Product product) {
+        productMapper.update(product);
+    }
+
+    @Override
+    public void deleteProduct(Integer id) {
+        productMapper.deleteById(id);
+    }
+
+    @Override
+    public PageResult<Product> getProductsByPage(int page, int size) {
+        int offset = (page - 1) * size;
+        List<Product> data = productMapper.selectByPage(offset, size);
+        int total = productMapper.countAll();
+        return new PageResult<>(data, total);
+    }
 }

--- a/ec/ec-backend/src/main/resources/mapper/ProductMapper.xml
+++ b/ec/ec-backend/src/main/resources/mapper/ProductMapper.xml
@@ -9,6 +9,33 @@
     SELECT * FROM products
   </select>
 
+  <resultMap id="ProductWithCategoryResult" type="com.example.ecbackend.entity.Product">
+    <id property="id" column="id"/>
+    <result property="name" column="name"/>
+    <result property="price" column="price"/>
+    <result property="imageUrl" column="image_url"/>
+    <result property="stock" column="stock"/>
+    <result property="categoryId" column="category_id"/>
+    <result property="categoryName" column="category_name"/>
+  </resultMap>
+
+  <select id="selectWithCategory" resultMap="ProductWithCategoryResult">
+    SELECT p.*, c.name AS category_name
+    FROM products p
+    LEFT JOIN product_category c ON p.category_id = c.id
+  </select>
+
+  <select id="selectByPage" resultMap="ProductWithCategoryResult">
+    SELECT p.*, c.name AS category_name
+    FROM products p
+    LEFT JOIN product_category c ON p.category_id = c.id
+    LIMIT #{offset}, #{size}
+  </select>
+
+  <select id="countAll" resultType="int">
+    SELECT COUNT(*) FROM products
+  </select>
+
   <select id="findById" parameterType="int" resultType="com.example.ecbackend.entity.Product">
     SELECT * FROM products WHERE id = #{id}
   </select>

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -24,7 +24,12 @@ instance.interceptors.request.use(
 // 响应拦截器（可选）：处理错误统一提示
 instance.interceptors.response.use(
   response => {
-    return response
+    const res = response.data
+    if (res.code !== 200) {
+      alert(res.msg || '请求失败')
+      return Promise.reject(new Error(res.msg || 'error'))
+    }
+    return res
   },
   error => {
     if (error.response) {

--- a/frontend/src/views/CategoryView.vue
+++ b/frontend/src/views/CategoryView.vue
@@ -203,11 +203,7 @@ const handleDeleteCategory = async () => {
   if (!selectedCategoryId.value) return
 
   try {
-    const check = await axios.get(`/categories/can-delete/${selectedCategoryId.value}`)
-    if (check.data.code === 1) {
-      ElMessage.warning(check.data.message)
-      return
-    }
+    await axios.get(`/categories/can-delete/${selectedCategoryId.value}`)
 
     await ElMessageBox.confirm('确定删除此分类吗？', '提示', {
       confirmButtonText: '确定',
@@ -215,15 +211,11 @@ const handleDeleteCategory = async () => {
       type: 'warning'
     })
 
-    const res = await axios.delete(`/categories/${selectedCategoryId.value}`)
-    if (res.data.code === 0) {
-      ElMessage.success('删除成功')
-      selectedCategoryId.value = null
-      selectedCategoryData.value = null
-      await loadCategories()
-    } else {
-      ElMessage.warning(res.data.message || '删除失败')
-    }
+    await axios.delete(`/categories/${selectedCategoryId.value}`)
+    ElMessage.success('删除成功')
+    selectedCategoryId.value = null
+    selectedCategoryData.value = null
+    await loadCategories()
   } catch (err) {
     if (err && err !== 'cancel' && err !== 'close') {
       ElMessage.error('请求失败')


### PR DESCRIPTION
## Summary
- introduce `Response<T>` generic wrapper
- rename `PageResult` field to `records`
- refactor controllers to return `Response`
- update axios interceptor and product/category views for paginated API

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685a6212e9e88322b1b0583e631f4cee